### PR TITLE
Add crude oil XGBoost example

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ Project Organization
     │   ├── models         <- Scripts to train models and then use trained models to make
     │   │   │                 predictions
     │   │   ├── predict_model.py
-    │   │   └── train_model.py
+    │   │   ├── train_model.py
+    │   │   └── crude_oil_xgboost.py  <- XGBoost model for Crude Oil futures
     │   │
     │   └── visualization  <- Scripts to create exploratory and results oriented visualizations
     │       └── visualize.py

--- a/models/crude_oil_xgboost.py
+++ b/models/crude_oil_xgboost.py
@@ -1,0 +1,73 @@
+# This script downloads front-month crude oil futures data and trains an XGBoost binary classifier
+# to predict next-day direction. It uses RandomizedSearchCV with TimeSeriesSplit cross validation.
+
+import pandas as pd
+import numpy as np
+import yfinance as yf
+from sklearn.metrics import classification_report, accuracy_score
+from sklearn.model_selection import RandomizedSearchCV, TimeSeriesSplit
+from xgboost import XGBClassifier
+
+
+# --- Fetch daily crude oil futures data from Yahoo Finance ---
+def fetch_crude_oil(start="2010-01-01", end=None):
+    ticker = "CL=F"  # front month crude oil futures symbol on Yahoo Finance
+    df = yf.download(ticker, start=start, end=end)
+    df = df.dropna()
+    return df
+
+
+# --- Feature engineering ---
+def make_features(df):
+    df = df.copy()
+    df["return_1d"] = df["Close"].pct_change()
+    df["return_5d"] = df["Close"].pct_change(5)
+    df["return_10d"] = df["Close"].pct_change(10)
+    df["rolling_std_5"] = df["Close"].rolling(5).std()
+    df["rolling_std_10"] = df["Close"].rolling(10).std()
+    df.dropna(inplace=True)
+    df["target"] = (df["Close"].shift(-1) > df["Close"]).astype(int)
+    df.dropna(inplace=True)
+    features = df.drop(columns=["target"])
+    target = df["target"]
+    return features, target
+
+
+# --- Train model with RandomizedSearchCV and TimeSeriesSplit ---
+def train_xgb_classifier(X, y):
+    param_dist = {
+        "max_depth": [3, 4, 5, 6],
+        "learning_rate": [0.01, 0.05, 0.1, 0.2],
+        "subsample": [0.8, 1.0],
+        "colsample_bytree": [0.8, 1.0],
+        "n_estimators": [100, 200, 300],
+    }
+    model = XGBClassifier(
+        objective="binary:logistic",
+        eval_metric="logloss",
+        random_state=42,
+        use_label_encoder=False,
+    )
+    tscv = TimeSeriesSplit(n_splits=5)
+    search = RandomizedSearchCV(
+        estimator=model,
+        param_distributions=param_dist,
+        n_iter=10,
+        cv=tscv,
+        scoring="roc_auc",
+        verbose=1,
+        random_state=42,
+        n_jobs=-1,
+    )
+    search.fit(X, y)
+    return search
+
+
+if __name__ == "__main__":
+    df = fetch_crude_oil()
+    X, y = make_features(df)
+    search = train_xgb_classifier(X, y)
+    print("Best parameters:\n", search.best_params_)
+    preds = search.predict(X)
+    print("Accuracy:", accuracy_score(y, preds))
+    print(classification_report(y, preds))

--- a/requirements.txt
+++ b/requirements.txt
@@ -183,3 +183,5 @@ wrapt==1.10.11
 yarl==1.2.6
 zict==0.1.3
 zope.interface==4.5.0
+xgboost==3.0.2
+yfinance==0.2.65


### PR DESCRIPTION
## Summary
- add a new script that downloads crude oil futures prices and fits an XGBoost classifier with `RandomizedSearchCV` and `TimeSeriesSplit`
- document the new example in the project README
- list `xgboost` and `yfinance` as dependencies

## Testing
- `python -m py_compile models/crude_oil_xgboost.py`
- `pytest -q`
- `python test_environment.py`

------
https://chatgpt.com/codex/tasks/task_e_68721a2140788321ae0658bac8d38f49

## Summary by Sourcery

Add a crude oil futures classification example using XGBoost with cross-validation, update dependencies, and document the new script

New Features:
- Add a crude oil XGBoost example script to train a binary classifier on futures data

Build:
- Add xgboost and yfinance to project dependencies

Documentation:
- Document the new crude oil XGBoost example in the README